### PR TITLE
Add redcarpet gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
 source 'https://rubygems.org'
 gem 'github-pages', group: :jekyll_plugins
+gem 'redcarpet', '~> 3.0.0'


### PR DESCRIPTION
After installing redcarpet gem and related dependencies, and run Jekyll Serve, there are always compile error shows redcarpet not install. But, finally I find there is a missing on this gem file

I am newbie on Ruby and Jekyll, I took some hours to solve this issue. So, that would be great if you can add installation page to show how to deploy the project in local?
